### PR TITLE
Fix doc to use DenopsPluginPost for settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,21 @@ The increment/decrement is done according to the rules set in
 `g:dps_dial#augends`.
 
 ```vim
-let g:dps_dial#augends = [
-\   'decimal',
-\   'date-slash',
-\   {'kind': 'constant', 'opts': {'elements': ['true', 'false']}},
-\   {'kind': 'case', 'opts': {'cases': ['camelCase', 'snake_case'], 'cyclic': v:true}},
-\ ]
+function! s:dps_dial_settings() abort
+  let g:dps_dial#augends += ['boolean']
+  call extend(g:dps_dial#aliases, {
+  \   'boolean': {
+  \     'kind': 'constant',
+  \     'opts': {
+  \       'elements': ['true', 'false'],
+  \       'word': v:true,
+  \       'cyclic': v:true,
+  \     },
+  \   },
+  \ })
+endfunction
+
+autocmd User DenopsPluginPost:dial call <SID>dps_dial_settings()
 ```
 
 Note that if there is a buffer-local variable `b:dps_dial_augends`, it will be

--- a/doc/dps-dial.jax
+++ b/doc/dps-dial.jax
@@ -751,6 +751,28 @@ CONFIGURATIONS							*dps-dial-configurations*
 ------------------------------------------------------------------------------
 VARIABLES								*dps-dial-variables*
 
+これらの変数は *DenopsPluginPost:dial* 発火時に設定されるため、
+ユーザは *autocmd* を使って *DenopsPluginPost* イベントのタイミングで
+設定を行う必要があります。
+
+>
+	function! s:dps_dial_settings() abort
+	  let g:dps_dial#augends += ['boolean']
+	  call extend(g:dps_dial#aliases, {
+	  \   'boolean': {
+	  \     'kind': 'constant',
+	  \     'opts': {
+	  \       'elements': ['true', 'false'],
+	  \       'word': v:true,
+	  \       'cyclic': v:true,
+	  \     },
+	  \   },
+	  \ })
+	endfunction
+
+	autocmd User DenopsPluginPost:dial call <SID>dps_dial_settings()
+<
+
 g:dps_dial#augends						*g:dps_dial#augends*
 		有効な増減ルール (augend) のリスト。レジスタ名などを特に指定せずに
 		<C-a> や <C-x> を押したとき、ここで設定されたルールに則って増減を行い


### PR DESCRIPTION
Because the denops plugin is loaded after VimEnter, it is not possible to read values set in TypeScript with vimrc.
Therefore, variable settings need to be executed after the plugin is loaded using autocmd.