### PR TITLE
Fix the first line so that it is judged as a ja doc

### DIFF
--- a/doc/dps-dial.jax
+++ b/doc/dps-dial.jax
@@ -1,4 +1,4 @@
-*dps-dial.txt*  Enhanced CTRL-A / CTRL-X powered by |denops.vim|
+*dps-dial.txt* 日本語ヘルプ  Enhanced CTRL-A / CTRL-X powered by |denops.vim|
 
 Vimの標準機能である CTRL-A / CTRL-X を拡張し、英数字に限らない様々な文字列を
 インクリメント/デクリメントできるようにするパッケージです。


### PR DESCRIPTION
The current help file is not judged as Japanese help because there is no Japanese written in the first line.
This is why I added Japanese to the first line.